### PR TITLE
create SpecUtil to handle common api request config and common assertions

### DIFF
--- a/src/test/java/com/api/tests/CountApiTest.java
+++ b/src/test/java/com/api/tests/CountApiTest.java
@@ -8,6 +8,7 @@ import org.testng.annotations.Test;
 import static com.api.constants.Role.*;
 import static com.api.utils.AuthTokenProvider.*;
 import com.api.utils.ConfigManager;
+import com.api.utils.SpecUtil;
 
 import io.restassured.http.ContentType;
 import io.restassured.http.Header;
@@ -19,19 +20,13 @@ public class CountApiTest {
 
 	@Test
 	public void verifyCountApiResponse() {
-		Header authHeader=new Header("Authorization",getToken(FD));
+		
 		given()
-		.baseUri(ConfigManager.getProperty("BASE_URL"))
-		.accept(ContentType.JSON)
-		.contentType(ContentType.JSON)
-		.header(authHeader)
-		.log().uri().log().headers().log().body()
+		.spec(SpecUtil.requestSpecWithAuth(FD))
 		.when()
 		.get("dashboard/count")
 		.then()
-		.log().body()
-		.statusCode(200)
-		.time(lessThan(1000L))
+		.spec(SpecUtil.responseSpec_Ok())
 		.body("message",equalTo("Success"))
 		.body("data", notNullValue())
 		.body("data.size()",equalTo(3))
@@ -44,14 +39,10 @@ public class CountApiTest {
 	@Test
 	public void countApiTestMissingAuthToken() {
 		given()
-		.baseUri(ConfigManager.getProperty("BASE_URL"))
-		.accept(ContentType.JSON)
-		.contentType(ContentType.JSON)
-		.log().all()
+		.spec(SpecUtil.RequestSpec())
 		.when()
 		.get("dashboard/count")
 		.then()
-		.log().all()
-		.statusCode(401);
+		.spec(SpecUtil.responseSpec_TEXT(401));
 	}
 }

--- a/src/test/java/com/api/tests/LoginApiTest.java
+++ b/src/test/java/com/api/tests/LoginApiTest.java
@@ -7,6 +7,8 @@ import static org.hamcrest.Matchers.*;
 import org.testng.annotations.Test;
 
 import com.api.pojo.UserCredentials;
+import com.api.utils.SpecUtil;
+
 import static com.api.utils.ConfigManager.*;
 
 
@@ -19,19 +21,10 @@ public class LoginApiTest {
 	public void loginApiTest() {
 		UserCredentials userCredentials =new UserCredentials("iamfd","password");
 		given()
-		.baseUri(getProperty("BASE_URL"))
-		.and()
-		.contentType(ContentType.JSON)
-		.accept(ContentType.JSON)
-		.body(userCredentials)
-		.log().uri()
-		.log().headers()
-		.log().body()
+		.spec(SpecUtil.RequestSpec(userCredentials))
 		.and()
 		.post("login")
-		.then().log().body()
-		.statusCode(200)
-		.time(lessThan(1000L))
+		.then().spec(SpecUtil.responseSpec_Ok())
 		.body("message", equalTo("Success"))
 		.and()
 		.body(JsonSchemaValidator.matchesJsonSchemaInClasspath("response-schema/LoginResponseSchema.json"));

--- a/src/test/java/com/api/tests/MasterApiTest.java
+++ b/src/test/java/com/api/tests/MasterApiTest.java
@@ -3,6 +3,8 @@ package com.api.tests;
 import static org.hamcrest.Matchers.*;
 import org.testng.annotations.Test;
 
+import com.api.utils.SpecUtil;
+
 import static com.api.constants.Role.*;
 import static com.api.utils.AuthTokenProvider.*;
 import static com.api.utils.ConfigManager.*;
@@ -17,22 +19,15 @@ public class MasterApiTest {
 	
 	@Test
 	public void masterApiTest() {
-		Header authHeader=new Header("Authorization",getToken(FD));
 		
 		given()
-		.baseUri(getProperty("BASE_URL"))
-		.contentType("")
-		.accept(ContentType.JSON)
-		.header(authHeader)
-		.log().uri().log().headers().log().body()
+		.spec(SpecUtil.requestSpecWithAuth(FD))
 		.when()
 		.post("master")
 		.then()
-		.log().all()
-		.statusCode(200)
+		.spec(SpecUtil.responseSpec_Ok())
 		.body("message", equalTo("Success"))
 		.body("data", notNullValue())
-		.time(lessThan(1000L))
 		.body("$", hasKey("data"))
 		.body("data", hasKey("mst_oem"))
 		.body("data", hasKey("mst_model"))
@@ -45,15 +40,10 @@ public class MasterApiTest {
 	@Test
 	public void masterApiInvalidToken() {
 		given()
-		.baseUri(getProperty("BASE_URL"))
-		.contentType("")
-		.accept(ContentType.JSON)
-		.header("","")
-		.log().uri().log().headers().log().body()
+		.spec(SpecUtil.RequestSpec())
 		.when()
 		.post("master")
 		.then()
-		.log().all()
-		.statusCode(401);
+		.spec(SpecUtil.responseSpec_TEXT(401));
 	}
 }

--- a/src/test/java/com/api/tests/UserDetailsApiTest.java
+++ b/src/test/java/com/api/tests/UserDetailsApiTest.java
@@ -6,6 +6,8 @@ import static org.hamcrest.Matchers.lessThan;
 
 import org.testng.annotations.Test;
 
+import com.api.utils.SpecUtil;
+
 import static com.api.constants.Role.*;
 
 import static com.api.utils.AuthTokenProvider.*;
@@ -21,21 +23,12 @@ public class UserDetailsApiTest {
 	@Test
 	public void userDetailsApiTest() {
 
-		Header authHeader =new Header("Authorization", getToken(FD));
 		given()
-		.baseUri(getProperty("BASE_URL"))
-		.and()
-		.contentType(ContentType.JSON)
-		.accept(ContentType.JSON)
-		.header(authHeader)
-		.log().uri()
-		.log().headers()
-		.log().body()
-		.and()
+		.spec(SpecUtil.requestSpecWithAuth(FD))
+		.when()
 		.get("userdetails")
-		.then().log().body()
-		.statusCode(200)
-		.time(lessThan(1000L))
+		.then()
+		.spec(SpecUtil.responseSpec_Ok())
 		.body("message", equalTo("Success"))
 		.and()
 		.body(JsonSchemaValidator.matchesJsonSchemaInClasspath("response-schema/UserDetailsResponseSchema.json"));

--- a/src/test/java/com/api/utils/SpecUtil.java
+++ b/src/test/java/com/api/utils/SpecUtil.java
@@ -1,0 +1,96 @@
+package com.api.utils;
+
+import org.hamcrest.Matchers;
+
+import com.api.constants.Role;
+import com.api.pojo.UserCredentials;
+
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.builder.ResponseSpecBuilder;
+import io.restassured.filter.log.LogDetail;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import io.restassured.specification.ResponseSpecification;
+
+/*
+ * SpecUtil class helps in defining the static methods for RequestSpecification and ResponseSpecification
+ * RequestSpecification - We use RequestSpecBuilder class for building RequestSpecification
+ * Its working is like builder design pattern where we create an object by providing the configuration and 
+ * in the end we use build() method so that we can return the object
+ * 
+ * 
+ * 
+ * 									
+ */
+public class SpecUtil {
+
+	// GET--DEL
+	public static RequestSpecification RequestSpec() {
+
+		RequestSpecification requestSpecification = new RequestSpecBuilder()
+				.setBaseUri(ConfigManager.getProperty("BASE_URL")).setContentType(ContentType.JSON)
+				.setAccept(ContentType.JSON).log(LogDetail.URI).log(LogDetail.METHOD).log(LogDetail.HEADERS)
+				.log(LogDetail.BODY).build();
+
+		return requestSpecification;
+	}
+
+	//POST
+	public static RequestSpecification RequestSpec(Object userCredentials) {
+
+		RequestSpecification requestSpecification = new RequestSpecBuilder()
+				.setBaseUri(ConfigManager.getProperty("BASE_URL"))
+				.setContentType(ContentType.JSON)
+				.setAccept(ContentType.JSON)
+				.setBody(userCredentials)
+				.log(LogDetail.URI)
+				.log(LogDetail.METHOD)
+				.log(LogDetail.HEADERS)
+				.log(LogDetail.BODY)
+				.build();
+
+		return requestSpecification;
+	}
+	
+	public static RequestSpecification requestSpecWithAuth(Role role) {
+		RequestSpecification requestSpecification =new RequestSpecBuilder()
+				.setBaseUri(ConfigManager.getProperty("BASE_URL"))
+				.setContentType(ContentType.JSON)
+				.setAccept(ContentType.JSON)
+				.addHeader("Authorization", AuthTokenProvider.getToken(role))
+				.log(LogDetail.URI)
+				.log(LogDetail.METHOD)
+				.log(LogDetail.HEADERS)
+				.log(LogDetail.BODY)
+				.build();
+		return requestSpecification;
+	}
+	public static ResponseSpecification responseSpec_Ok() {
+		ResponseSpecification responseSpecification=new ResponseSpecBuilder()
+		.expectContentType(ContentType.JSON)
+		.expectStatusCode(200)
+		.expectResponseTime(Matchers.lessThan(1000L))
+		.log(LogDetail.ALL)
+		.build();
+		return responseSpecification;
+	}
+	public static ResponseSpecification responseSpec_JSON(int statusCode) {
+		ResponseSpecification responseSpecification=new ResponseSpecBuilder()
+		.expectContentType(ContentType.JSON)
+		.expectStatusCode(statusCode)
+		.expectResponseTime(Matchers.lessThan(1000L))
+		.log(LogDetail.ALL)
+		.build();
+		return responseSpecification;
+	}
+	public static ResponseSpecification responseSpec_TEXT(int statusCode) {
+		ResponseSpecification responseSpecification=new ResponseSpecBuilder()
+		.expectStatusCode(statusCode)
+		.expectResponseTime(Matchers.lessThan(1000L))
+		.log(LogDetail.ALL)
+		.build();
+		return responseSpecification;
+	}
+	
+	
+}


### PR DESCRIPTION
SpecUtils is consisting of common RequestSpecBuilder and ResponseSpecBuilder. These utils methods has reduced the boilerplate code in our api test and also reduced number of lines. Making test code smaller and maintable